### PR TITLE
PR 1/2: Add only a submission indicator

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,7 +262,7 @@ availability_card = dbc.Card(
 )
 
 ready_style = {
-    "max-width": "50%",
+    "max-width": "100%",
     "marginBottom": "5px",
     "outline": False,
 }
@@ -276,8 +276,18 @@ solve_card = dbc.Card(
     [
         dbc.CardBody(
             [
-                dbc.Button("Solve CQM", id="btn_solve_cqm", style=ready_style),
-                html.Div(id="trigger", children=0, style=dict(display="none")),
+                dbc.Row([
+                    dbc.Col([
+                        dbc.Button("Solve CQM", id="btn_solve_cqm", style=ready_style),
+                        html.Div(id="trigger", children=0, style=dict(display="none")),
+                    ], width=6),
+                    dbc.Col([
+                        dbc.FormText("Submission status:", style={"color": col},
+                        ),
+                        dcc.Textarea(id="submission_indicator", value="Ready to solve",
+                            style={"width": "100%"}, rows=2)
+                    ], width=6)
+                ])
             ]
         )
     ],

--- a/app.py
+++ b/app.py
@@ -284,7 +284,7 @@ solve_card = dbc.Card(
                     dbc.Col([
                         dbc.FormText("Submission status:", style={"color": col},
                         ),
-                        dcc.Textarea(id="submission_indicator", value="Ready",
+                        dcc.Textarea(id="submission_indicator", value="Ready to solve",
                             style={"width": "100%"}, rows=2),
                         dcc.Interval(id="submission_timer", interval=None, n_intervals=0, disabled=True),
                     ], width=6)
@@ -550,12 +550,10 @@ def submission_mngr(
     trigger = callback_context.triggered
     trigger_id = trigger[0]["prop_id"].split(".")[0]
 
-    print(f"trigger_id = {trigger_id} n_clicks = {n_clicks}")
-
     if trigger_id == "btn_solve_cqm" and n_clicks:
-        return "Submitting...", 1000, False, "avail"     
+        return "Submitting... please wait", 1000, False, "avail"     
         
-    if trigger_id == "submission_timer" and submission_indicator_val == "Submitting...":
+    if trigger_id == "submission_timer" and submission_indicator_val == "Submitting... please wait":
         if active_tab == "avail":
             return no_update, no_update, False, no_update
         else:
@@ -590,7 +588,7 @@ def submitter(
     built_sched,
     e_card,
 ):
-    if submission_indicator_val == "Ready":
+    if submission_indicator_val == "Ready to solve":
         return (
             html.Label("Not constructed yet.", style={"max-width": "50%"}),
             None,
@@ -600,7 +598,7 @@ def submitter(
     elif submission_indicator_val == "Done":
         return built_sched, e_card, "sched"
     
-    elif submission_indicator_val == "Submitting...":
+    elif submission_indicator_val == "Submitting... please wait":
         shifts = list(sched_df["props"]["data"][0].keys())
         shifts.remove("Employee")
         availability = utils.availability_to_dict(


### PR DESCRIPTION
This PR addresses [this review comment](https://github.com/dwave-examples/employee-scheduling/pull/18#discussion_r1447897691) on a missing dash indicator for submissions. In a few minutes I will make a [second PR](https://github.com/vgoliber/employee-scheduling-1/pull/2) that addresses that comment but also some other ones (seems easier to demonstrate than to describe through the multiple comments of my first review). I'd recommend merging just the [second PR](https://github.com/vgoliber/employee-scheduling-1/pull/2), ignoring this one, and then updating to your liking based on that. 

Note: now that this update of the example is not scheduled for the week after next, I've been pulled off to other work so I have not got the time to fully test. It seems to be working well enough but you can probably improve the new code. 