### PR TITLE
PR 2/2: Add a submission indicator & replace collapsible with tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ title_card = dbc.Card(
                 dbc.Row(
                     [
                         html.H1(
-                            children="Employee Scheduling Demo",
+                            children="Employee Scheduling",
                             style={
                                 "textAlign": "center",
                                 "font-family": ff,
@@ -274,14 +274,12 @@ solve_card = dbc.Card(
                     dbc.Col([
                         dbc.Button("Solve CQM", id="btn_solve_cqm", style=ready_style),
                         html.Div(id="trigger", children=0, style=dict(display="none")),
-                    ], width=6),
-                    dbc.Col([
                         dbc.FormText("Submission status:", style={"color": col},
                         ),
                         dcc.Textarea(id="submission_indicator", value="Ready to solve",
                             style={"width": "100%"}, rows=2),
                         dcc.Interval(id="submission_timer", interval=None, n_intervals=0, disabled=True),
-                    ], width=6)
+                    ], width=6),
                 ])
             ]
         )
@@ -391,13 +389,24 @@ app.layout = html.Div(
                         dbc.Col(
                             [
                                 input_card,
-                                solve_card,
                             ],
                             style={
                                 "padding": 10,
                             },
                             width=3,
                         ),
+                        dbc.Col(
+                            [
+                                solve_card,
+                            ],
+                            style={
+                                "padding": 10,
+                            },
+                            width={"size": 3, "offset": 3},
+                        ),
+                    ]),
+                dbc.Row(
+                    [
                         dbc.Col(
                             dbc.Tabs(
                                 id="tabs",

--- a/app.py
+++ b/app.py
@@ -76,61 +76,56 @@ input_card = dbc.Card(
     [
         dbc.CardBody(
             [
-                html.P(
-                    "Number of Employees:  ",
-                    style={"font-family": ff, "color": col},
-                ),
-                dbc.Input(
-                    id="input_employees",
-                    type="number",
-                    placeholder="#",
-                    min=4,
-                    max=200,
-                    step=1,
-                    value=12,
-                    style={"marginBottom": "5px", "outline": False},
-                ),
-                html.P(
-                    "Optional random seed: ",
-                    style={"font-family": ff, "color": col},
-                ),
-                dbc.Input(
-                    id="seed",
-                    type="number",
-                    placeholder="(Optional) Random Seed",
-                    min=1,
-                    style={"marginBottom": "5px", "outline": False},
-                ),
-                html.P(
-                    "Autofill scenario: ",
-                    style={"font-family": ff, "color": col},
-                ),
-                dcc.Dropdown(
-                    ["Small", "Medium", "Large"],
-                    placeholder="Select a scenario",
-                    id="demo-dropdown",
-                ),
-            ]
-        )
-    ],
-    className="border-0 bg-transparent",
-)
 
-settings_card = dbc.Card(
-    [
-        dbc.CardBody(
-            [
-                dbc.Button(
-                    "Additional Options",
-                    id="collapse-button",
-                    className="mb-3",
-                    color="primary",
-                    n_clicks=0,
-                ),
-                dbc.Collapse(
-                    dbc.Card(
-                        dbc.CardBody(
-                            [
+                dbc.Tabs(
+                    id="input_tabs",
+                    active_tab="basic",
+                    children=[
+                        dbc.Tab(
+                            tab_id="basic",
+                            children=[
+                                html.P(
+                                    "Number of Employees:  ",
+                                    style={"font-family": ff, "color": col},
+                                ),
+                                dbc.Input(
+                                    id="input_employees",
+                                    type="number",
+                                    placeholder="#",
+                                    min=4,
+                                    max=200,
+                                    step=1,
+                                    value=12,
+                                    style={"marginBottom": "5px", "outline": False},
+                                ),
+                                html.P(
+                                    "Optional random seed: ",
+                                    style={"font-family": ff, "color": col},
+                                ),
+                                dbc.Input(
+                                    id="seed",
+                                    type="number",
+                                    placeholder="(Optional) Random Seed",
+                                    min=1,
+                                    style={"marginBottom": "5px", "outline": False},
+                                ),
+                                html.P(
+                                    "Autofill scenario: ",
+                                    style={"font-family": ff, "color": col},
+                                ),
+                                dcc.Dropdown(
+                                    ["Small", "Medium", "Large"],
+                                    placeholder="Select a scenario",
+                                    id="demo-dropdown",
+                                ),
+                            ],
+                            label="Basic",
+                            active_label_style={"color": "black"},
+                            label_style={"color": "white"},
+                        ),
+                        dbc.Tab(
+                            tab_id="more",
+                            children=[
                                 dbc.Checklist(
                                     options=[
                                         {
@@ -229,17 +224,16 @@ settings_card = dbc.Card(
                                         "outline": False,
                                     },
                                 ),
-                            ]
-                        ),
-                        className="border-0 bg-transparent",
-                    ),
-                    id="collapse",
-                    is_open=False,
-                ),
+                            ],
+                            label="More Options",
+                            active_label_style={"color": "black"},
+                            label_style={"color": "white"},
+                        ),                
             ]
         )
     ],
-    className="border-0 bg-transparent",
+    ),], 
+    className="border-0 bg-transparent"
 )
 
 availability_card = dbc.Card(
@@ -398,7 +392,6 @@ app.layout = html.Div(
                             [
                                 input_card,
                                 solve_card,
-                                settings_card,
                             ],
                             style={
                                 "padding": 10,
@@ -660,18 +653,6 @@ def submitter(
 
     else:
         return no_update, no_update, no_update
-
-
-@app.callback(
-    Output("collapse", "is_open"),
-    [Input("collapse-button", "n_clicks")],
-    [State("collapse", "is_open")],
-)
-def toggle_collapse(n, is_open):
-    if n:
-        return not is_open
-    return is_open
-
 
 if __name__ == "__main__":
     app.run_server(debug=True)

--- a/app.py
+++ b/app.py
@@ -76,7 +76,6 @@ input_card = dbc.Card(
     [
         dbc.CardBody(
             [
-
                 dbc.Tabs(
                     id="input_tabs",
                     active_tab="basic",
@@ -84,148 +83,162 @@ input_card = dbc.Card(
                         dbc.Tab(
                             tab_id="basic",
                             children=[
-                                html.P(
-                                    "Number of Employees:  ",
-                                    style={"font-family": ff, "color": col},
-                                ),
-                                dbc.Input(
-                                    id="input_employees",
-                                    type="number",
-                                    placeholder="#",
-                                    min=4,
-                                    max=200,
-                                    step=1,
-                                    value=12,
-                                    style={"marginBottom": "5px", "outline": False},
-                                ),
-                                html.P(
-                                    "Optional random seed: ",
-                                    style={"font-family": ff, "color": col},
-                                ),
-                                dbc.Input(
-                                    id="seed",
-                                    type="number",
-                                    placeholder="(Optional) Random Seed",
-                                    min=1,
-                                    style={"marginBottom": "5px", "outline": False},
-                                ),
-                                html.P(
-                                    "Autofill scenario: ",
-                                    style={"font-family": ff, "color": col},
-                                ),
-                                dcc.Dropdown(
-                                    ["Small", "Medium", "Large"],
-                                    placeholder="Select a scenario",
-                                    id="demo-dropdown",
-                                ),
+
+                                dbc.Row([
+                                    dbc.Col([
+
+                                        html.P(
+                                            "Number of Employees:  ",
+                                            style={"font-family": ff, "color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="input_employees",
+                                            type="number",
+                                            placeholder="#",
+                                            min=4,
+                                            max=200,
+                                            step=1,
+                                            value=12,
+                                            style={"marginBottom": "5px", "outline": False},
+                                        ),
+                                        html.P(
+                                            "Example scenario: ",
+                                            style={"font-family": ff, "color": col},
+                                        ),
+                                        dcc.Dropdown(
+                                            ["Small", "Medium", "Large"],
+                                            placeholder="Select a scenario",
+                                            id="demo-dropdown",
+                                        ),
+                                        dbc.FormText(
+                                            "Max consecutive shifts:",
+                                            style={"color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="cons shifts",
+                                            type="number",
+                                            placeholder="Max consecutive shifts",
+                                            min=1,
+                                            value=5,
+                                            style={
+                                                "max-width": "50%",
+                                                "marginBottom": "5px",
+                                                "outline": False,
+                                            },
+                                        ),
+                                    ], width=4),
+                                ]),
                             ],
-                            label="Basic",
+                            label="Basic Configuration",
                             active_label_style={"color": "black"},
                             label_style={"color": "white"},
                         ),
                         dbc.Tab(
                             tab_id="more",
                             children=[
-                                dbc.Checklist(
-                                    options=[
-                                        {
-                                            "label": "Allow isolated days off",
-                                            "value": 1,
-                                        },
-                                        {
-                                            "label": "Require exactly one manager on every shift",
-                                            "value": 2,
-                                        },
-                                    ],
-                                    value=[2],
-                                    id="checklist-input",
-                                    style={
-                                        "color": col,
-                                        "font-family": ff,
-                                    },
-                                ),
-                                dbc.FormText(
-                                    "Min shifts per employee:",
-                                    style={"color": col},
-                                ),
-                                dbc.Input(
-                                    id="min shifts",
-                                    type="number",
-                                    placeholder="Min shifts per employee",
-                                    min=0,
-                                    value=10,
-                                    style={
-                                        "max-width": "50%",
-                                        "marginBottom": "5px",
-                                        "outline": False,
-                                    },
-                                ),
-                                dbc.FormText(
-                                    "Max shifts per employee:",
-                                    style={"color": col},
-                                ),
-                                dbc.Input(
-                                    id="max shifts",
-                                    type="number",
-                                    placeholder="Max shifts per employee",
-                                    min=0,
-                                    value=20,
-                                    style={
-                                        "max-width": "50%",
-                                        "marginBottom": "5px",
-                                        "outline": False,
-                                    },
-                                ),
-                                dbc.FormText(
-                                    "Min employees per shift:",
-                                    style={"color": col},
-                                ),
-                                dbc.Input(
-                                    id="shifts min",
-                                    type="number",
-                                    placeholder="Min employees per shift",
-                                    min=0,
-                                    value=1,
-                                    style={
-                                        "max-width": "50%",
-                                        "marginBottom": "5px",
-                                        "outline": False,
-                                    },
-                                ),
-                                dbc.FormText(
-                                    "Max employees per shift:",
-                                    style={"color": col},
-                                ),
-                                dbc.Input(
-                                    id="shifts max",
-                                    type="number",
-                                    placeholder="Max employees per shift",
-                                    min=1,
-                                    value=6,
-                                    style={
-                                        "max-width": "50%",
-                                        "marginBottom": "5px",
-                                        "outline": False,
-                                    },
-                                ),
-                                dbc.FormText(
-                                    "Max consecutive shifts:",
-                                    style={"color": col},
-                                ),
-                                dbc.Input(
-                                    id="cons shifts",
-                                    type="number",
-                                    placeholder="Max consecutive shifts",
-                                    min=1,
-                                    value=5,
-                                    style={
-                                        "max-width": "50%",
-                                        "marginBottom": "5px",
-                                        "outline": False,
-                                    },
-                                ),
+                                dbc.Row([
+                                    dbc.Col([
+                                        html.P(
+                                            "Optional random seed: ",
+                                            style={"font-family": ff, "color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="seed",
+                                            type="number",
+                                            placeholder="(Optional) Random Seed",
+                                            min=1,
+                                            style={"marginBottom": "5px", "outline": False},
+                                        ),
+                                        dbc.Checklist(
+                                            options=[
+                                                {
+                                                    "label": "Allow isolated days off",
+                                                    "value": 1,
+                                                },
+                                                {
+                                                    "label": "Require exactly one manager on every shift",
+                                                    "value": 2,
+                                                },
+                                            ],
+                                            value=[2],
+                                            id="checklist-input",
+                                            style={
+                                                "color": col,
+                                                "font-family": ff,
+                                            },
+                                        ),
+                                    ]),
+                                    dbc.Col([
+                                        dbc.FormText(
+                                            "Min shifts per employee:",
+                                            style={"color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="min shifts",
+                                            type="number",
+                                            placeholder="Min shifts per employee",
+                                            min=0,
+                                            value=10,
+                                            style={
+                                                "max-width": "50%",
+                                                "marginBottom": "5px",
+                                                "outline": False,
+                                            },
+                                        ),
+                                        dbc.FormText(
+                                            "Max shifts per employee:",
+                                            style={"color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="max shifts",
+                                            type="number",
+                                            placeholder="Max shifts per employee",
+                                            min=0,
+                                            value=20,
+                                            style={
+                                                "max-width": "50%",
+                                                "marginBottom": "5px",
+                                                "outline": False,
+                                            },
+                                        ),
+                                    ]),
+                                    dbc.Col([
+                                        dbc.FormText(
+                                            "Min employees per shift:",
+                                            style={"color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="shifts min",
+                                            type="number",
+                                            placeholder="Min employees per shift",
+                                            min=0,
+                                            value=1,
+                                            style={
+                                                "max-width": "50%",
+                                                "marginBottom": "5px",
+                                                "outline": False,
+                                            },
+                                        ),
+                                        dbc.FormText(
+                                            "Max employees per shift:",
+                                            style={"color": col},
+                                        ),
+                                        dbc.Input(
+                                            id="shifts max",
+                                            type="number",
+                                            placeholder="Max employees per shift",
+                                            min=1,
+                                            value=6,
+                                            style={
+                                                "max-width": "50%",
+                                                "marginBottom": "5px",
+                                                "outline": False,
+                                            },
+                                        ),
+                                    ]), 
+                                ]),    
                             ],
-                            label="More Options",
+                            label="Advanced Configuration",
                             active_label_style={"color": "black"},
                             label_style={"color": "white"},
                         ),                
@@ -393,7 +406,7 @@ app.layout = html.Div(
                             style={
                                 "padding": 10,
                             },
-                            width=3,
+                            width=6,
                         ),
                         dbc.Col(
                             [
@@ -402,7 +415,7 @@ app.layout = html.Div(
                             style={
                                 "padding": 10,
                             },
-                            width={"size": 3, "offset": 3},
+                            width={"size": 3, "offset": 1},
                         ),
                     ]),
                 dbc.Row(

--- a/app.py
+++ b/app.py
@@ -262,7 +262,7 @@ availability_card = dbc.Card(
 )
 
 ready_style = {
-    "max-width": "50%",
+    "max-width": "100%",
     "marginBottom": "5px",
     "outline": False,
 }
@@ -276,8 +276,18 @@ solve_card = dbc.Card(
     [
         dbc.CardBody(
             [
-                dbc.Button("Solve CQM", id="btn_solve_cqm", style=ready_style),
-                html.Div(id="trigger", children=0, style=dict(display="none")),
+                dbc.Row([
+                    dbc.Col([
+                        dbc.Button("Solve CQM", id="btn_solve_cqm", style=ready_style),
+                        html.Div(id="trigger", children=0, style=dict(display="none")),
+                    ], width=6),
+                    dbc.Col([
+                        dbc.FormText("Submission status:", style={"color": col},
+                        ),
+                        dcc.Textarea(id="submission_indicator", value="Ready to solve",
+                            style={"width": "100%"}, rows=2)
+                    ], width=6)
+                ])
             ]
         )
     ],

--- a/app.py
+++ b/app.py
@@ -284,7 +284,7 @@ solve_card = dbc.Card(
                     dbc.Col([
                         dbc.FormText("Submission status:", style={"color": col},
                         ),
-                        dcc.Textarea(id="submission_indicator", value="Ready",
+                        dcc.Textarea(id="submission_indicator", value="Ready to solve",
                             style={"width": "100%"}, rows=2),
                         dcc.Interval(id="submission_timer", interval=None, n_intervals=0, disabled=True),
                     ], width=6)
@@ -550,12 +550,10 @@ def submission_mngr(
     trigger = callback_context.triggered
     trigger_id = trigger[0]["prop_id"].split(".")[0]
 
-    print(f"trigger_id = {trigger_id} n_clicks = {n_clicks}")
-
     if trigger_id == "btn_solve_cqm" and n_clicks:
-        return "Submitting...", 1000, False, "avail"     
+        return "Submitting... please wait", 1000, False, "avail"     
         
-    if trigger_id == "submission_timer" and submission_indicator_val == "Submitting...":
+    if trigger_id == "submission_timer" and submission_indicator_val == "Submitting... please wait":
         if active_tab == "avail":
             return no_update, no_update, False, no_update
         else:
@@ -590,7 +588,7 @@ def submitter(
     built_sched,
     e_card,
 ):
-    if submission_indicator_val == "Ready":
+    if submission_indicator_val == "Ready to solve":
         return (
             html.Label("Not constructed yet.", style={"max-width": "50%"}),
             None,
@@ -600,7 +598,7 @@ def submitter(
     elif submission_indicator_val == "Done":
         return built_sched, e_card, "sched"
     
-    elif submission_indicator_val == "Submitting...":
+    elif submission_indicator_val == "Submitting... please wait":
         shifts = list(sched_df["props"]["data"][0].keys())
         shifts.remove("Employee")
         availability = utils.availability_to_dict(


### PR DESCRIPTION
This PR addresses [this review comment](https://github.com/dwave-examples/employee-scheduling/pull/18#discussion_r1447897691) on a missing dash indicator for submissions. It also addresses some other comments: seems easier to demonstrate than to describe through the multiple comments of my first review. I'd recommend merging just this PR, ignoring [this one](https://github.com/vgoliber/employee-scheduling-1/pull/1), and then updating to your liking based on that.

Note: now that this update of the example is not scheduled for the week after next, I've been pulled off to other work so I have not got the time to fully test. It seems to be working well enough but you can probably improve the new code.

The additional commits make the page simpler for a first look by new users and rearrange a few inputs:

![image](https://github.com/vgoliber/employee-scheduling-1/assets/34041130/6410cb44-3f4b-4d5e-b7a7-06fbf1efe417)
